### PR TITLE
[Optimisation] do not write same boundary

### DIFF
--- a/src/main/java/com/mappy/fpm/batches/merge/FilteredGeometrySerializer.java
+++ b/src/main/java/com/mappy/fpm/batches/merge/FilteredGeometrySerializer.java
@@ -43,6 +43,12 @@ public class FilteredGeometrySerializer implements GeometrySerializer {
     }
 
     @Override
+    public long writeBoundary(LineString line, Map<String, String> tags) {
+        delegate(line, tags);
+        return 0;
+    }
+
+    @Override
     public void write(MultiLineString polygon, Map<String, String> tags) {
         delegate(polygon, tags);
     }

--- a/src/main/java/com/mappy/fpm/batches/tomtom/helpers/BoundariesShapefile.java
+++ b/src/main/java/com/mappy/fpm/batches/tomtom/helpers/BoundariesShapefile.java
@@ -11,7 +11,6 @@ import com.vividsolutions.jts.geom.*;
 import org.jetbrains.annotations.NotNull;
 import org.openstreetmap.osmosis.core.domain.v0_6.Node;
 import org.openstreetmap.osmosis.core.domain.v0_6.RelationMember;
-import org.openstreetmap.osmosis.core.domain.v0_6.Way;
 
 import java.io.File;
 import java.util.List;
@@ -35,12 +34,12 @@ public class BoundariesShapefile extends TomtomShapefile {
     protected BoundariesShapefile(String filename, int tomtomLevel, NameProvider nameProvider, OsmLevelGenerator osmLevelGenerator) {
         super(filename);
         String[] split = filename.split("/");
-        String zone = split[split.length-1].split("_[_2]")[0];
+        String zone = split[split.length - 1].split("_[_2]")[0];
 
         this.osmLevel = osmLevelGenerator.getOsmLevel(zone, String.valueOf(tomtomLevel));
         this.tomtomLevel = String.valueOf(tomtomLevel);
         this.nameProvider = nameProvider;
-        if(new File(filename).exists()) {
+        if (new File(filename).exists()) {
             this.nameProvider.loadFromFile("___an.dbf", "NAME", false);
         }
     }
@@ -70,7 +69,7 @@ public class BoundariesShapefile extends TomtomShapefile {
             addPointWithRoleLabel(serializer, members, pointTags, multiPolygon);
             for (int i = 0; i < multiPolygon.getNumGeometries(); i++) {
                 Polygon polygon = (Polygon) multiPolygon.getGeometryN(i);
-                for (int j=0; j < polygon.getNumInteriorRing(); j++){
+                for (int j = 0; j < polygon.getNumInteriorRing(); j++) {
                     for (Geometry geom : LongLineSplitter.split(polygon.getInteriorRingN(j), 100)) {
                         addRelationMember(serializer, members, wayTags, (LineString) geom, "inner");
                     }
@@ -101,8 +100,8 @@ public class BoundariesShapefile extends TomtomShapefile {
     }
 
     private void addRelationMember(GeometrySerializer serializer, List<RelationMember> members, Map<String, String> wayTags, LineString geom, String memberRole) {
-        Way way = serializer.write(geom, wayTags);
-        members.add(new RelationMember(way.getId(), Way, memberRole));
+        Long wayId = serializer.writeBoundary(geom, wayTags);
+        members.add(new RelationMember(wayId, Way, memberRole));
     }
 
     private void addPointWithRoleLabel(GeometrySerializer serializer, List<RelationMember> members, Map<String, String> tags, MultiPolygon multiPolygon) {

--- a/src/main/java/com/mappy/fpm/batches/utils/GeometrySerializer.java
+++ b/src/main/java/com/mappy/fpm/batches/utils/GeometrySerializer.java
@@ -31,5 +31,7 @@ public interface GeometrySerializer extends Closeable {
 
     Way write(LineString line, Map<String, String> tags);
 
+    long writeBoundary(LineString line, Map<String, String> tags);
+
     long writeRelation(List<RelationMember> members, Map<String, String> tags);
 }

--- a/src/test/java/com/mappy/fpm/batches/utils/OsmosisSerializerTest.java
+++ b/src/test/java/com/mappy/fpm/batches/utils/OsmosisSerializerTest.java
@@ -140,6 +140,46 @@ public class OsmosisSerializerTest {
     }
 
     @Test
+    public void should_write_boundary() throws Exception {
+        serializer.writeBoundary(linestring(
+                new Coordinate[]{
+                        new Coordinate(0.0, 0.0),
+                        new Coordinate(1.0, 0.0),
+                        new Coordinate(2.0, 0.0)}),
+                Maps.newHashMap());
+
+        serializer.writeBoundary(linestring(
+                new Coordinate[]{
+                        new Coordinate(0.0, 1.0),
+                        new Coordinate(1.0, 1.0),
+                        new Coordinate(0.0, 2.0)}),
+                Maps.newHashMap());
+
+        assertThat(sink.getEntities()).filteredOn(e -> e instanceof Node).hasSize(6);
+        assertThat(sink.getEntities()).filteredOn(e -> e instanceof Way).hasSize(2);
+    }
+
+    @Test
+    public void should_not_write_same_boundary() throws Exception {
+        serializer.writeBoundary(linestring(
+                new Coordinate[]{
+                        new Coordinate(0.0, 0.0),
+                        new Coordinate(1.0, 0.0),
+                        new Coordinate(2.0, 0.0)}),
+                Maps.newHashMap());
+
+        serializer.writeBoundary(linestring(
+                new Coordinate[]{
+                        new Coordinate(0.0, 0.0),
+                        new Coordinate(1.0, 0.0),
+                        new Coordinate(2.0, 0.0)}),
+                Maps.newHashMap());
+
+        assertThat(sink.getEntities()).filteredOn(e -> e instanceof Node).hasSize(3);
+        assertThat(sink.getEntities()).filteredOn(e -> e instanceof Way).hasSize(1);
+    }
+
+    @Test
     public void should_write_polygon() throws Exception {
         serializer.write(
                 polygon(new Coordinate(0.0, 0.0), new Coordinate(1.0, 0.0), new Coordinate(1.0, 1.0), new Coordinate(0.0, 1.0), new Coordinate(0.0, 0.0)),

--- a/src/test/java/com/mappy/fpm/utils/MemoryGeometrySerializer.java
+++ b/src/test/java/com/mappy/fpm/utils/MemoryGeometrySerializer.java
@@ -59,4 +59,10 @@ public class MemoryGeometrySerializer implements GeometrySerializer {
         relations.add(tags);
         return 0;
     }
+
+    @Override
+    public long writeBoundary(LineString line, Map<String, String> tags) {
+        linetrings.add(tags);
+        return 0;
+    }
 }


### PR DESCRIPTION
In OSM we have one boundary for one or more relations. 

In the previous version we created one boundary with one relation.