### PR TITLE
Add tag for ramp for exit/entrances roads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: java
 jdk:
   - oraclejdk8

--- a/src/main/java/com/mappy/fpm/batches/tomtom/helpers/RoadTagger.java
+++ b/src/main/java/com/mappy/fpm/batches/tomtom/helpers/RoadTagger.java
@@ -122,8 +122,9 @@ public class RoadTagger {
 
         tagRoute(feature, tags, id, isOneway, isReversed);
 
-        addTagIf("ramp_type", () -> feature.getInteger("RAMP").equals(1) ? "exit" : "entrance", 
-            ofNullable(feature.getInteger("RAMP")).isPresent() && (feature.getInteger("RAMP").equals(1) || feature.getInteger("RAMP").equals(2)), tags);
+        Integer ramp = feature.getInteger("RAMP");
+        addTagIf("ramp_type", () -> ramp.equals(1) ? "exit" : "entrance",
+            ofNullable(ramp).isPresent() && (ramp.equals(1) || ramp.equals(2)), tags);
 
         tags.putAll(geocodeProvider.getInterpolations(id));
 

--- a/src/main/java/com/mappy/fpm/batches/tomtom/helpers/RoadTagger.java
+++ b/src/main/java/com/mappy/fpm/batches/tomtom/helpers/RoadTagger.java
@@ -122,6 +122,9 @@ public class RoadTagger {
 
         tagRoute(feature, tags, id, isOneway, isReversed);
 
+        addTagIf("ramp_type", () -> feature.getInteger("RAMP").equals(1) ? "exit" : "entrance", 
+            ofNullable(feature.getInteger("RAMP")).isPresent() && (feature.getInteger("RAMP").equals(1) || feature.getInteger("RAMP").equals(2)), tags);
+
         tags.putAll(geocodeProvider.getInterpolations(id));
 
         geocodeProvider.getLeftPostalCode(id).ifPresent(postcodes -> tags.put("is_in:left", postcodes));

--- a/src/test/java/com/mappy/fpm/batches/tomtom/helpers/RoadTaggerTest.java
+++ b/src/test/java/com/mappy/fpm/batches/tomtom/helpers/RoadTaggerTest.java
@@ -479,4 +479,15 @@ public class RoadTaggerTest {
                 .containsEntry("source:country:download_job", "mockcountry")
                 .containsEntry("source:zone:tomtom", "mockzone");
     }
+
+    @Test
+    public void should_add_is_exit() {
+    	defaultTags.put("RAMP", "1");
+      assertThat(tagger.tagData(onlyTags(defaultTags)))
+              .containsEntry("ramp_type", "exit");
+
+    	defaultTags.put("RAMP", "2");
+            assertThat(tagger.tagData(onlyTags(defaultTags)))
+            .containsEntry("ramp_type", "entrance");
+    }
 }


### PR DESCRIPTION
Add ramp_type info (exit or entrance) to be able to set exit number only on exits.